### PR TITLE
fix armv7 detection during image build

### DIFF
--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -10,7 +10,7 @@ echo
 # install thin-edge.io
 arch=$(uname -m)
 case "$arch" in
-    *arm7*)
+    *armv7*)
         # Due to differences between the build process and the target device, the arch
         # used for installation needs to be forced to armv6.
         echo "Using armv6 workaround" | tee -a "${RECIPE_DIR}/build.log"


### PR DESCRIPTION
Fix a typo which led to the Raspberry Pi 1 and Zero images with incorrect thin-edge.io targets being installed (arm64 instead of armv6)