### PR TITLE
fix: persist etc hosts file

### DIFF
--- a/recipes/thin-edge.io/files/tedge-config.toml
+++ b/recipes/thin-edge.io/files/tedge-config.toml
@@ -7,3 +7,6 @@ directory = "/var/log/tedge"
 # mosquitto db file must be persisted
 [[persist]]
 directory = "/var/lib/mosquitto"
+
+[[persist]]
+file = "/etc/hosts"


### PR DESCRIPTION
Keep edits to the /etc/hosts as it contains host specific information