### PR TITLE
feat: set device.type on bootstrapping

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-bootstrap
+++ b/recipes/tedge-bootstrap/files/tedge-bootstrap
@@ -100,4 +100,17 @@ if [ -n "$C8Y_URL" ]; then
     configure_c8y "$C8Y_URL"
 fi
 
+# set device type
+# FIXME: Work out a better way to get the device type, maybe extend tedge-identity to include device info, it could also
+# be referenced from 80_c8y_Firmware
+if [ -f /usr/share/tedge-inventory/scripts.d/80_c8y_Firmware ]; then
+    DEVICE_TYPE=$(/usr/share/tedge-inventory/scripts.d/80_c8y_Firmware | grep "name=" | cut -d= -f2 | tr -d '"' | xargs)
+    if [ -n "$DEVICE_TYPE" ]; then
+        log "Setting device.type to $DEVICE_TYPE"
+        tedge config set device.type "$DEVICE_TYPE"
+    else
+        log "Using default device.type: $(tedge config get device.type)"
+    fi
+fi
+
 touch "$RAN_MARKER"


### PR DESCRIPTION
Set device.type on bootstrapping to the value returned by the c8y_Firmware inventory script. This prevents users from accidentally applying the wrong base image to the wrong device.