### PR TITLE
fix: wait for filesystem to be mounted before executing

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-bootstrap
+++ b/recipes/tedge-bootstrap/files/tedge-bootstrap
@@ -67,12 +67,15 @@ set_hostname() {
         return
     fi
     echo "$host_name" | tee /etc/hostname
-    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+
     if ! hostnamectl set-hostname "$host_name"; then
         log "hostnamectl failed, falling back to writing to /etc/hostname"
         echo "$host_name" > /etc/hostname
     fi
     systemctl restart avahi-daemon --no-block 2>/dev/null ||:
+
+    # enable local network calls to reference current host name
+    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
 }
 
 if [ $# -gt 0 ]; then

--- a/recipes/tedge-bootstrap/files/tedge-bootstrap.service
+++ b/recipes/tedge-bootstrap/files/tedge-bootstrap.service
@@ -2,6 +2,7 @@
 Description=Set hostname on startup
 Wants=network-pre.target
 Before=network-pre.target
+After=local-fs.target
 ConditionPathExists=!/etc/tedge/.bootstrapped
 
 [Service]


### PR DESCRIPTION
Fix bug where the tedge-bootstrap is running before the /etc directory is mounted for read/write