### PR TITLE
fix: move hosts edit after other critical device setup

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-bootstrap
+++ b/recipes/tedge-bootstrap/files/tedge-bootstrap
@@ -73,9 +73,20 @@ set_hostname() {
         echo "$host_name" > /etc/hostname
     fi
     systemctl restart avahi-daemon --no-block 2>/dev/null ||:
+}
 
+set_etc_hosts() {
     # enable local network calls to reference current host name
-    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+    host_name="$1"
+    retries=10
+    while [ "$retries" -gt 0 ]; do
+        if sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts; then
+            break
+        fi
+        retries=$((retries - 1))
+        log "Failed to set /etc/hosts record. Retries left $retries"
+        sleep 2
+    done
 }
 
 if [ $# -gt 0 ]; then
@@ -96,8 +107,8 @@ while [ "$attempt" -lt 30 ]; do
     sleep 5
 done
 
-set_hostname "$DEVICE_ID"
 create_cert "$DEVICE_ID"
+set_hostname "$DEVICE_ID"
 
 if [ -n "$C8Y_URL" ]; then
     configure_c8y "$C8Y_URL"
@@ -115,5 +126,7 @@ if [ -f /usr/share/tedge-inventory/scripts.d/80_c8y_Firmware ]; then
         log "Using default device.type: $(tedge config get device.type)"
     fi
 fi
+
+set_etc_hosts "$DEVICE_ID"
 
 touch "$RAN_MARKER"


### PR DESCRIPTION
Perform edit of /etc/hosts after other critical setup has been run (e.g. creation of certificates etc.)

Also add basic retry mechanism in case if the /etc/ is busy