### PR TITLE
fix(firmware): workflow fixes on commit and rollback

### DIFF
--- a/recipes/tedge-firmware-update/files/firware_update.rugpi.toml
+++ b/recipes/tedge-firmware-update/files/firware_update.rugpi.toml
@@ -42,7 +42,7 @@ on_success = { status = "failed", reason = "Device failed to restart" }
 
 [verify]
 script = "/usr/bin/rugpi_workflow.sh ${.payload.status} --firmware-name ${.payload.name} --firmware-version ${.payload.version} --url ${.payload.remoteUrl}"
-on_exit.0 = { status = "successful" }
+on_exit.0 = { status = "commit" }
 on_exit.4 = { status = "rollback_restart", reason = "Verification failed. Rolling back to default partition" }
 on_exit._ = { status = "failed", reason = "Verification failed, no rollback necessary" }
 

--- a/recipes/tedge-firmware-update/files/firware_update.rugpi.toml
+++ b/recipes/tedge-firmware-update/files/firware_update.rugpi.toml
@@ -52,7 +52,7 @@ on_success = "successful"
 on_error = { status = "rollback_restart", reason = "Commit failed. Rolling back to default partition" }
 
 [rollback_restart]
-script = "restart"
+action = "restart"
 on_exec = "restarting"  # Internal state used by the "restart" action
 on_success = "rollback_successful"
 


### PR DESCRIPTION
Minor fixes to the firmware_update workflow.
* Transition to commit rather than successful after verification
* Fix syntax error on the `rollback_restart` state to use the `action` rather than the `script` property