### PR TITLE
fix(firmware): refresh the default partition from rugpi before publishing the event to the user

### DIFF
--- a/recipes/tedge-firmware-update/files/rugpi_workflow.sh
+++ b/recipes/tedge-firmware-update/files/rugpi_workflow.sh
@@ -271,6 +271,9 @@ commit() {
 
     case "$EXIT_CODE" in
         0)
+            # Check what the updated default partition is
+            DEFAULT=$(rugpi-ctrl system info | grep Default | cut -d: -f2 | tr '[:lower:]' '[:upper:]' | xargs)
+
             log "Commit successful. New default partition is $DEFAULT"
             # Save firmware meta information to file (for reading on startup during normal operation)
             local_log "Saving firmware info to $FIRMWARE_META_FILE"


### PR DESCRIPTION
Fix the event text after commiting a new default partition by refreshing the state before publishing the event.