### PR TITLE
chore: publish firmware info on generic twin topic

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-bootstrap
+++ b/recipes/tedge-bootstrap/files/tedge-bootstrap
@@ -112,9 +112,9 @@ fi
 
 # set device type
 # FIXME: Work out a better way to get the device type, maybe extend tedge-identity to include device info, it could also
-# be referenced from 80_c8y_Firmware
-if [ -f /usr/share/tedge-inventory/scripts.d/80_c8y_Firmware ]; then
-    DEVICE_TYPE=$(/usr/share/tedge-inventory/scripts.d/80_c8y_Firmware | grep "name=" | cut -d= -f2 | tr -d '"' | xargs)
+# be referenced from 80_firmware
+if [ -f /usr/share/tedge-inventory/scripts.d/80_firmware ]; then
+    DEVICE_TYPE=$(/usr/share/tedge-inventory/scripts.d/80_firmware | grep "name=" | cut -d= -f2 | tr -d '"' | xargs)
     if [ -n "$DEVICE_TYPE" ]; then
         log "Setting device.type to $DEVICE_TYPE"
         tedge config set device.type "$DEVICE_TYPE"

--- a/recipes/tedge-firmware-update/steps/00-install.sh
+++ b/recipes/tedge-firmware-update/steps/00-install.sh
@@ -4,7 +4,7 @@ install -D -m 644 "${RECIPE_DIR}/files/tedge-firmware" -t /etc/sudoers.d/
 install -D -m 644 "${RECIPE_DIR}/files/system.toml" -t /etc/tedge/
 install -D -m 644 "${RECIPE_DIR}/files/firmware_update.rugpi.toml" -t /usr/share/tedge-workflows/
 install -D -m 755 "${RECIPE_DIR}/files/rugpi_workflow.sh" -t /usr/bin/
-install -D -m 755 "${RECIPE_DIR}/files/firmware-version" /usr/share/tedge-inventory/scripts.d/80_c8y_Firmware
+install -D -m 755 "${RECIPE_DIR}/files/firmware-version" /usr/share/tedge-inventory/scripts.d/80_firmware
 
 # auto rollback service incase if new agent is corrupt (only rely on tooling which is definitely there)
 install -D -m 755 "${RECIPE_DIR}/files/firmware-auto-rollback" /usr/bin/firmware-auto-rollback


### PR DESCRIPTION
publish firmware information to `/twin/firmware` topic (instead of c8y specific `/twin/c8y_Firmware`)