### PR TITLE
feat: detect rpi compute modules 3 and 4

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-identity
+++ b/recipes/tedge-bootstrap/files/tedge-identity
@@ -73,6 +73,12 @@ get_model_type() {
         Raspberry\ Pi\ Zero\ W\ Rev*)
             MODEL_PREFIX=rpizero
             ;;
+        Raspberry\ Pi\ Compute\ Module\ 3*)
+            MODEL_PREFIX=rpicm3
+            ;;
+        Raspberry\ Pi\ Compute\ Module\ 4*)
+            MODEL_PREFIX=rpicm4
+            ;;
         *)
             MODEL_PREFIX=unknown
             ;;


### PR DESCRIPTION
Detect Raspberry Pi Compute Modules and use the following device-id prefixes:

* Compute Module 3 => rpicm3
* Compute Module 3 => rpicm4