### PR TITLE
fix(identity): resolve shellcheck warnings

### DIFF
--- a/recipes/tedge-bootstrap/files/tedge-identity
+++ b/recipes/tedge-bootstrap/files/tedge-identity
@@ -43,8 +43,8 @@ get_mac_address() {
 }
 
 get_model_type() {
-    MODEL=$(cat /proc/cpuinfo  | grep Model | cut -d: -f2 | xargs)
-    SERIAL_NO=$(cat /proc/cpuinfo  | grep Serial | cut -d: -f2 | xargs)
+    MODEL=$(grep Model /proc/cpuinfo | cut -d: -f2 | xargs)
+    SERIAL_NO=$(grep Serial /proc/cpuinfo | cut -d: -f2 | xargs)
 
     echo "Detected model: $MODEL" >&2
     echo "Detected serial no.: $SERIAL_NO" >&2


### PR DESCRIPTION
Resolve shellcheck warnings by grepping file directly rather than using cat.