### PR TITLE
feat: add default log and configuration plugin settings

### DIFF
--- a/recipes/thin-edge.io/files/tedge-configuration-plugin.toml
+++ b/recipes/thin-edge.io/files/tedge-configuration-plugin.toml
@@ -11,4 +11,4 @@ path = "/etc/tedge/plugins/tedge-log-plugin.toml"
 type = "tedge-log-plugin"
 user = "tedge"
 group = "tedge"
-mode = 0o0444
+mode = 0o0644

--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -52,3 +52,7 @@ fi
 
 # Persist tedge configuration and related components (e.g. mosquitto)
 install -D -m 644 "${RECIPE_DIR}/files/tedge-config.toml" -t /etc/rugpi/state
+
+# Add default plugin configurations
+install -D -m 644 -g tedge -o tedge "${RECIPE_DIR}/files/tedge-configuration-plugin.toml" -t /etc/tedge/plugins/
+install -D -m 644 -g tedge -o tedge "${RECIPE_DIR}/files/tedge-log-plugin.toml" -t /etc/tedge/plugins/


### PR DESCRIPTION
Include sensible default configuration files for:

* tedge-log-plugin.toml
* tedge-configuration-plugin.toml

The configuration files include default settings based on the other features offered by the image.