### PR TITLE
feat: install mosquitto from bookworm backports repo instead of sid

### DIFF
--- a/recipes/mosquitto/steps/00-install.sh
+++ b/recipes/mosquitto/steps/00-install.sh
@@ -3,13 +3,9 @@
 # The mosquitto repo can't be used as it does not included builds for arm64/aarch64 (only amd64 and armhf)
 # * https://github.com/eclipse/mosquitto/issues/2604 (2.0.11)
 # * https://github.com/eclipse/mosquitto/issues/2634 (2.0.15)
-echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/debian-sid.list
+echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/debian-bookworm-backports.list
 apt-get update
 
-DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confold -y --no-install-recommends install \
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confold -y --no-install-recommends install -t bookworm-backports \
     mosquitto \
     mosquitto-clients
-
-# Remove sid afterwards to prevent unexpected packages from being installed
-rm -f /etc/apt/sources.list.d/debian-sid.list
-apt-get update ||:


### PR DESCRIPTION
mosquitto is now installed using the bookworm-backport APT repository rather than sid. The backports repo is also left configured to easy updating the version at runtime