### PR TITLE
fix(set-wifi): support setting network connection id via recipe

### DIFF
--- a/recipes/set-wifi/recipe.toml
+++ b/recipes/set-wifi/recipe.toml
@@ -2,5 +2,6 @@ description = "Set wifi access"
 default = false
 
 [parameters]
+id = { default = "wifi" }
 ssid = {}
 password = {}

--- a/recipes/set-wifi/steps/00-install.sh
+++ b/recipes/set-wifi/steps/00-install.sh
@@ -4,7 +4,7 @@ echo "Setting wifi access"
 
 cat << EOT > /etc/NetworkManager/system-connections/wifi.nmconnection
 [connection]
-id=asio uplink
+id=${RECIPE_PARAM_ID}
 uuid=354ca6a0-bc96-4a29-82f4-c7cbc6e43fac
 type=wifi
 


### PR DESCRIPTION
The `set-wifi` receipe now support setting the `id` field of the NetworkManager wifi connection (before it was set to a fixed string).