### PR TITLE
fix: avoid warning message when installing binfmt by install all formats

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,8 +41,10 @@ show:
     @echo "BUILD_INFO: {{BUILD_INFO}}"
 
 # Setup binfmt tools
+# Note: technically only arm64,armhf are required, however install 'all' avoids the error message
+# on arm64 hosts
 setup:
-    docker run --privileged --rm tonistiigi/binfmt --install arm64,armhf
+    docker run --privileged --rm tonistiigi/binfmt --install all
 
 # Clean build
 clean:


### PR DESCRIPTION
Avoid warning message when installing binfmt by install all formats.

Previously when running `just setup`, the following error would appear to users when they are running from an arm64 host (e.g. MacOS m*)

```
installing: arm64 cannot register "/usr/bin/qemu-aarch64" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
``` 

