### PR TITLE
fix: remove misplaced comment for pi01 image definition

### DIFF
--- a/images/pi01.toml
+++ b/images/pi01.toml
@@ -2,5 +2,4 @@ architecture = "armhf"
 
 boot_flow = "u-boot"
 
-# Make image generic so it can be used for pi4 and pi5
 include_firmware = "none"


### PR DESCRIPTION
Removing erroneous comment due to a copy/paste error