### PR TITLE
fix(build): auto detection when to use when compressing the image using xz

### DIFF
--- a/scripts/compress.sh
+++ b/scripts/compress.sh
@@ -2,10 +2,22 @@
 set -e
 
 SUDO=
-if [ -n "$CI" ]; then
-    # use sudo when running in the CI otherwise the following error occurs
-    # regardless of the owner of the file and folder.
-    # xz: Cannot set the file group: Operation not permitted
+
+requires_sudo() {
+    if stat --help >/dev/null 2>&1; then
+        IMAGE_OWNER=$(stat -c "%u" "$1")
+    else
+        # bsd variant
+        IMAGE_OWNER=$(stat -f "%u" "$1")
+    fi
+    [ "$IMAGE_OWNER" = 0 ]
+}
+
+# On some systems docker creates the image as the root user which
+# requires running xz with sudo otherwise the following error occurs:
+# xz: Cannot set the file group: Operation not permitted
+if requires_sudo "$1"; then
+    echo "Image is owned by root, so compressing using sudo" >&2
     SUDO=sudo
 fi
 


### PR DESCRIPTION
Improve build process by automatically detecting when to use sudo when running `just bake`.

This is required as on some setups (e.g. linux), the `.img` file produced is owned by root and not the host user which then causes a problem when compressing the image.