### PR TITLE
Add docker recipe

### DIFF
--- a/recipes/docker/00-install.sh
+++ b/recipes/docker/00-install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# Add Docker's official GPG key:
+
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+   tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+
+apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+usermod -aG docker tedge

--- a/recipes/docker/recipe.toml
+++ b/recipes/docker/recipe.toml
@@ -1,0 +1,4 @@
+description = "install latest docker version"
+priority = 10_000
+dependencies = ["thin-edge.io"]
+default = false


### PR DESCRIPTION
This recipe will install Docker to the pi images. It will install after ThinEdge and add the tedge user the the docker group.