### PR TITLE
chore: use fixed rugpi version

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ export IMAGE_URL_ARMHF := "https://downloads.raspberrypi.org/raspios_lite_armhf/
 export IMAGE_ARCH := "arm64"
 
 export IMAGE_URL := if IMAGE_ARCH != "armhf" { IMAGE_URL_ARM64 } else { IMAGE_URL_ARMHF }
-export RUGPI_IMAGE := "ghcr.io/silitics/rugpi-bakery:latest"
+export RUGPI_IMAGE := "ghcr.io/silitics/rugpi-bakery:v0.5"
 
 export PREFIX := "tedge_rugpi_"
 export PROFILE := "default"

--- a/run-bakery
+++ b/run-bakery
@@ -3,7 +3,7 @@
 set -e
 
 DOCKER=${DOCKER:-docker}
-RUGPI_IMAGE=${RUGPI_IMAGE:-ghcr.io/silitics/rugpi-bakery:latest}
+RUGPI_IMAGE=${RUGPI_IMAGE:-ghcr.io/silitics/rugpi-bakery:v0.5}
 
 $DOCKER run --rm --privileged \
     -v "$(pwd)":/project \


### PR DESCRIPTION
Use fixed verison of rugpi-bakery to avoid pulling in new versions unexpectedly