### PR TITLE
feat(docker): install tedge-container-plugin in recipe

### DIFF
--- a/recipes/docker/steps/00-install.sh
+++ b/recipes/docker/steps/00-install.sh
@@ -15,5 +15,12 @@ echo \
    tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt-get update
 
-apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+apt-get install -y --no-install-recommends \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    tedge-container-plugin
+
 usermod -aG docker tedge


### PR DESCRIPTION
Install tedge-container-plugin which is a thin-edge.io software management plugin to list, install, remove container and container groups (e.g. docker compose projects).