### PR TITLE
ci: fix publishing of release artifacts

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -108,3 +108,4 @@ jobs:
           draft: true
           files: |
             ./release/*/*
+            ./release/*/*/*


### PR DESCRIPTION
Fix bug where the images were not included in the release artifacts due to the glob not being wide enough.