### PR TITLE
fix: do not include firmware in `tryboot` images

### DIFF
--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -4,10 +4,12 @@ tedge-rugpi-core = { git = "https://github.com/thin-edge/tedge-rugpi-core.git" }
 # Image for Raspberry Pi 4, 5, CM4, 400
 [images.tryboot]
 layer = "default"
+include_firmware = "none"
 
 # Image for Raspberry Pi 4, 5, CM4, 400 - includes containerization dependencies
 [images.tryboot-containers]
 layer = "containers"
+include_firmware = "none"
 
 # A specific image including the firmware update for Raspberry Pi 4 and CM4.
 [images.pi4]

--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -20,14 +20,17 @@ include_firmware = "pi4"
 [images.u-boot]
 layer = "default"
 boot_flow = "u-boot"
+include_firmware = "none"
 
 # An image using the U-Boot boot flow for Raspberry Pi 3 and Zero 2 with containerization dependencies
 [images.u-boot-containers]
 layer = "containers"
 boot_flow = "u-boot"
+include_firmware = "none"
 
 # An `armhf` image for older Raspberry Pi's using the U-Boot boot flow.
 [images.u-boot-armhf]
 layer = "default"
 architecture = "armhf"
 boot_flow = "u-boot"
+include_firmware = "none"


### PR DESCRIPTION
The `include_firmware` option still needs to be set to `none` to prevent the firmware update for Pi 4 to be included. This was an oversight of mine. In the future, `none` will become the default.