### PR TITLE
build: include u-boot-containers image in workflow

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -46,6 +46,7 @@ jobs:
           - { image: tryboot }
           - { image: tryboot-containers }
           - { image: u-boot }
+          - { image: u-boot-containers }
           - { image: u-boot-armhf }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add the `u-boot-containers` image to the CI workflow.