### PR TITLE
feat(containers): set mqtt bind address to make broker accessible from containers

### DIFF
--- a/layers/containers.toml
+++ b/layers/containers.toml
@@ -4,6 +4,7 @@ parent = "tedge-rugpi-core/tedge"
 recipes = [
     "tedge-rugpi-core/defaults",
     "tedge-rugpi-core/docker",
+    "tedge-config",
 ]
 
 [parameters."core/apt-cleanup"]
@@ -11,3 +12,7 @@ autoremove = true
 
 [parameters."core/rugpi-ctrl"]
 rugpi_admin = true  # Enable Rugpi Admin.
+
+[parameters."tedge-config"]
+# Allow containers to reach the MQTT broker on the host
+mqtt_bind_address = "0.0.0.0"

--- a/recipes/tedge-config/recipe.toml
+++ b/recipes/tedge-config/recipe.toml
@@ -1,0 +1,6 @@
+description = "thin-edge.io custom configuration"
+priority = 10_000
+dependencies = ["tedge-rugpi-core/defaults"]
+
+[parameters]
+mqtt_bind_address = { default = "" }

--- a/recipes/tedge-config/steps/00-install.sh
+++ b/recipes/tedge-config/steps/00-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+if [ -n "$RECIPE_PARAM_MQTT_BIND_ADDRESS" ]; then
+    echo "Setting mqtt.bind.address to $RECIPE_PARAM_MQTT_BIND_ADDRESS" >&2
+    tedge config set mqtt.bind.address "$RECIPE_PARAM_MQTT_BIND_ADDRESS"
+fi


### PR DESCRIPTION
Add new recipe to set the thin-edge.io MQTT bind address so the MQTT broker accepts incoming connections from the docker network