### PR TITLE
ci: replace just action with snap installer

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v1
+      - run: sudo snap install --edge --classic just
       - id: info
         name: Get Version
         run: |
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: extractions/setup-just@v1
+      - run: sudo snap install --edge --classic just
       - name: Install dependencies
         run: just setup
       - id: info

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v1
+      - run: sudo snap install --edge --classic just
       - uses: reubenmiller/setup-go-c8y-cli@main
       - run: |
           echo "Name: ${{ github.event.release.name }} Description: ${{ github.event.release.body }}"


### PR DESCRIPTION
Install just using snap rather than relying on the github action as the action depends on the now deprecated nodejs v16.