### PR TITLE
Revert "ci: replace just action with snap installer"

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v1
       - id: info
         name: Get Version
         run: |
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v1
       - name: Install dependencies
         run: just setup
       - id: info

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v1
       - uses: reubenmiller/setup-go-c8y-cli@main
       - run: |
           echo "Name: ${{ github.event.release.name }} Description: ${{ github.event.release.body }}"


### PR DESCRIPTION
Reverts thin-edge/tedge-rugpi-image#72 as the version of just in the snapstore is very old (1.2.0 vs 1.22.0!)