### PR TITLE
feat(armhf): add armhf image with docker preinstalled

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The following images are included in this repository.
 |tryboot-containers|Image for Raspberry Pi 4 and 5 devices which use the tryboot bootloader and with docker pre-installed|
 |rpi4|Raspberry Pi 4 image which includes the firmware to enable tryboot bootloader|
 |u-boot|Image for Raspberry Pi 2, 3, zero 2W|
+|u-boot-containers|Image for Raspberry Pi 2, 3, zero 2W with docker pre-installed|
 |u-boot-armhf|Image for Raspberry Pi 1 and zero|
+|u-boot-armhf-containers|Image for Raspberry Pi 1 and zero with docker pre-installed|
 
 ## Building
 

--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -34,3 +34,9 @@ layer = "default"
 architecture = "armhf"
 boot_flow = "u-boot"
 include_firmware = "none"
+
+[images.u-boot-armhf-containers]
+layer = "containers"
+architecture = "armhf"
+boot_flow = "u-boot"
+include_firmware = "none"


### PR DESCRIPTION
Add new image for armhf builds which includes docker pre-installed.

You can build the image using:

```sh
just IMAGE=u-boot-armhf-containers build
```
