### PR TITLE
fix: mount gitconfig to avoid git permissions errors

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,4 @@
+[safe]
+    # Ignore the safe directories when building inside a container as the ownership
+    # of the repository folders can be unexpected
+    directory = *

--- a/run-bakery
+++ b/run-bakery
@@ -23,6 +23,7 @@ fi
 exec $DOCKER run --rm --privileged \
     $DOCKER_FLAGS \
     -v "$(pwd)":/project \
+    -v "$(pwd)/.gitconfig:/root/.gitconfig" \
     -v /dev:/dev \
     "${RUGPI_BAKERY_IMAGE}" \
     "$@"


### PR DESCRIPTION
Avoid an issue when building the image inside a docker container where git does not trust the project repository.