### PR TITLE
feat: support installing thin-edge.io pre-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ To run the build tasks, install [just](https://just.systems/man/en/chapter_5.htm
 For further information on Rugpi, checkout the [quick start guide](https://oss.silitics.com/rugpi/docs/getting-started).
 
 
+### Building images including thin-edge.io main
+
+To build an image with the latest pre-release version from the [main channel](https://thin-edge.github.io/thin-edge.io/contribute/package-hosting/#pre-releases), set the following environment variable in the `.env` file in your project:
+
+```sh
+# thin-edge.io install channel. Options: "main",  "release" (latest official release)
+TEDGE_INSTALL_CHANNEL=main
+```
+
 ### Building for your specific device type
 
 The different image options can be confusing, so to help users a few device specific tasks were created to help you pick the correct image.

--- a/env.template
+++ b/env.template
@@ -7,3 +7,7 @@ SECRETS_WIFI_PASSWORD=
 SSH_KEYS_bootstrap="ssh-rsa xxxxxxx"
 #SSH_KEYS_user1="ssh-rsa xxxxxxx"
 #SSH_KEYS_user2="ssh-rsa xxxxxxx"
+
+# thin-edge.io settings
+# thin-edge.io install channel. Options: "main",  "release" (latest official release)
+#TEDGE_INSTALL_CHANNEL=main


### PR DESCRIPTION
Support installing thin-edge.io pre-releases (from the main channel) by setting an environment variable in the dotenv file, `.env`:

```sh
# thin-edge.io install channel. Options: "main",  "release" (latest official release)
TEDGE_INSTALL_CHANNEL=main
```
