### PR TITLE
feat: update layer to include new networking and local pki improvements

### DIFF
--- a/layers/debian-containers.toml
+++ b/layers/debian-containers.toml
@@ -1,8 +1,10 @@
 parent = "tedge-rugpi-core/debian-bookworm-tedge"
 
 recipes = [
-    "tedge-rugpi-core/docker",
     "core/rugpi-ctrl",
+    "tedge-rugpi-core/docker",
+    "tedge-rugpi-core/systemd-resolved",
+    "tedge-rugpi-core/boot-options",
     "tedge-config",
 ]
 

--- a/layers/rpi-containers.toml
+++ b/layers/rpi-containers.toml
@@ -3,6 +3,8 @@ parent = "tedge-rugpi-core/raspios-tedge"
 recipes = [
     "core/rugpi-ctrl",
     "tedge-rugpi-core/docker",
+    "tedge-rugpi-core/systemd-resolved",
+    "tedge-rugpi-core/boot-options",
     "tedge-config",
 ]
 

--- a/layers/rpi-default.toml
+++ b/layers/rpi-default.toml
@@ -2,6 +2,8 @@ parent = "tedge-rugpi-core/raspios-tedge"
 
 recipes = [
     "core/rugpi-ctrl",
+    "tedge-rugpi-core/systemd-resolved",
+    "tedge-rugpi-core/boot-options",
 ]
 
 [parameters."core/rugpi-ctrl"]

--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -1,5 +1,5 @@
 [repositories]
-tedge-rugpi-core = { git = "https://github.com/thin-edge/tedge-rugpi-core.git", branch = "v0.7" }
+tedge-rugpi-core = { git = "https://github.com/thin-edge/tedge-rugpi-core.git", branch = "v0.8" }
 
 [images.debian-amd64]
 layer = "debian-default"


### PR DESCRIPTION
Update layer to include
* Support for resolving mdns addresses using systemd-resolved (stub DNS server)
* [tedge-pki-smallstep](https://github.com/thin-edge/tedge-pki-smallstep) community plugin to provide a local PKI (though still a work in progress)
* Enable cgroups memory monitoring