### PR TITLE
docs: include pizero2 in the list of devices an image can be applied to

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,7 +107,7 @@ build-pi2:
     @echo "This image can be applied to"
     @echo "  * pi2"
     @echo "  * pi3"
-    @echo "  * pizero2"
+    @echo "  * pizero2w"
     @echo
 
 build-pi3:
@@ -116,7 +116,7 @@ build-pi3:
     @echo "This image can be applied to"
     @echo "  * pi2"
     @echo "  * pi3"
-    @echo "  * pizero2"
+    @echo "  * pizero2w"
     @echo
 
 build-pizero2w:
@@ -125,6 +125,7 @@ build-pizero2w:
     @echo "This image can be applied to"
     @echo "  * pi2"
     @echo "  * pi3"
+    @echo "  * pizero2w"
     @echo
 
 build-pi4:


### PR DESCRIPTION
Added missing entries where the Raspberry Pi 2W device was not explicitly mentioned in the list of devices where an image was applicable to.

Now, when using the following task, pizero2w is included in the list:

```sh
$ just build-pizero2w

This image can be applied to
  * pi2
  * pi3
  * pizero2w
```
